### PR TITLE
[makedocs] Remove vestigial echo

### DIFF
--- a/makedocs
+++ b/makedocs
@@ -74,7 +74,6 @@ weasyprint documentation/source/pdftemp/versions.html documentation/pdf/versions
 echo "     > sample.html > sample.pdf"
 pandoc -s -f markdown-smart --template documentation/source/templatepdf.html documentation/source/sample.md -o documentation/source/pdftemp/sample.html --lua-filter=documentation/source/pandocfilters/filter-pdf.lua
 weasyprint documentation/source/pdftemp/sample.html documentation/pdf/sample.pdf
-echo "     > markdowntest.html > markdowntest.pdf"
 
 echo "     >>> PRODUCT SITE MARKDOWN (documentation/source/productsite/)"
 


### PR DESCRIPTION
This is echoing a description for code that was removed. This `echo` line is only present in one other font repo, where it is commented out (https://github.com/silnrsi/font-annapurna/pull/9). It is a different line than what was missed in another font repo (https://github.com/silnrsi/font-japa-sans-oriya/pull/1).